### PR TITLE
Fixes error with no voices being available on MacOS

### DIFF
--- a/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/SpeechEngineAbstract.java
+++ b/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/SpeechEngineAbstract.java
@@ -66,10 +66,12 @@ public abstract class SpeechEngineAbstract implements SpeechEngine {
         ArrayList<String> list = ProcessHelper.startApplicationAndGetOutput(getSayExecutable(), getSayOptionsToGetSupportedVoices());
         ArrayList<Voice> voices = new ArrayList<>();
         for (String line : list) {
-            Voice v = parse(line);
-            if (v != null) {
-                voices.add(v);
-            }
+            try {
+                Voice v = parse(line);
+                if (v != null) {
+                    voices.add(v);
+                }
+            } catch (ParseException e) { e.printStackTrace() }
         }
         availableVoices = voices;
     }


### PR DESCRIPTION
On MacOS 13+ there is an issue that arises whenever a single `ParseException` is thrown inside `findAvailableVoices()`. This PR fixes that by catching the exception. Another solution would be to fix the parser inside [`SpeechEngineMacOS.parse(...)`](https://github.com/jonelo/jAdapterForNativeTTS/blob/c2136f7d9045b2fc7042ebb6f178faffefd64c76/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/macos/SpeechEngineMacOS.java#L61), but I never got around to debugging how it failed.