### PR TITLE
`SpeechEngine.say()` returns the Process.

### DIFF
--- a/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/SpeechEngine.java
+++ b/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/SpeechEngine.java
@@ -51,7 +51,7 @@ public interface SpeechEngine {
     // actions
     void setVoice(String voice);
 
-    void say(String text) throws IOException;
+    Process say(String text) throws IOException;
 
     void stopTalking();
 

--- a/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/SpeechEngineAbstract.java
+++ b/src/main/java/io/github/jonelo/jAdapterForNativeTTS/engines/SpeechEngineAbstract.java
@@ -86,10 +86,12 @@ public abstract class SpeechEngineAbstract implements SpeechEngine {
         return null;
     }
 
-    public void say(String text) throws IOException {
+    public Process say(String text) throws IOException {
         if (voice != null) {
             process = ProcessHelper.startApplication(getSayExecutable(), getSayOptionsToSayText(text));
+            return process;
         }
+        return null;
     }
 
     /**
@@ -99,6 +101,7 @@ public abstract class SpeechEngineAbstract implements SpeechEngine {
     public void stopTalking() {
         if (process != null) {
             process.destroy();
+            process = null;
         }
     }
 


### PR DESCRIPTION
Applications may call `process.waitFor()` or `process.onExit()` etc

I'm not sure whether `say()` should return null or throw an exception if `voice` is null - probably the latter but this PR should not change the existing behaviour.